### PR TITLE
Add remove_space.py script

### DIFF
--- a/extra/README.md
+++ b/extra/README.md
@@ -57,6 +57,8 @@ In the case you have the `--ground-truth` or `--predicted` files in the right fo
 `python rename_class.py --current-class-name Picture Frame --new-class-name PictureFrame`
 
 ## Rename all classes by replacing spaces with delimiters
+Use this option instead of the above option when you have a lot of classes with spaces.
+It's useful when renaming classes with spaces become tedious (because you have a lot of them).
 
 1) Add class list to the file `class_list.txt` (the script will search this file for class names with spaces)
 2) Run the `remove_space.py` script and specify the `--delimiter` (default: "-") and `--yes` if you want to force confirmation on all yes/no queries, e.g.

--- a/extra/README.md
+++ b/extra/README.md
@@ -55,3 +55,10 @@ In the case you have the `--ground-truth` or `--predicted` files in the right fo
 1) Run the `rename_class.py` script and specify the `--current-class-name` and `--new-class-name` as arguments, e.g.
 
 `python rename_class.py --current-class-name Picture Frame --new-class-name PictureFrame`
+
+## Rename all classes by replacing spaces with delimiters
+
+1) Add class list to the file `class_list.txt` (the script will search this file for class names with spaces)
+2) Run the `remove_space.py` script and specify the `--delimiter` (default: "-") and `--yes` if you want to force confirmation on all yes/no queries, e.g.
+
+`python remove_space.py --delimiter "-" --yes`

--- a/extra/remove_space.py
+++ b/extra/remove_space.py
@@ -1,0 +1,95 @@
+import sys
+import os
+import glob
+import argparse
+
+# this script will load class_list.txt and find class names that have spaces in them
+# then replace spaces with delimiters inside ground-truth/ and predicted/
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-d', '--delimiter', type=str, help="delimiter to replace space (default: '-')", default='-')
+parser.add_argument('-y', '--yes', action='store_true', help="force yes confirmation on yes/no query (default: False)", default=False)
+args = parser.parse_args()
+
+def query_yes_no(question, default="yes", bypass=False):
+  """Ask a yes/no question via raw_input() and return their answer.
+
+  "question" is a string that is presented to the user.
+  "default" is the presumed answer if the user just hits <Enter>.
+      It must be "yes" (the default), "no" or None (meaning
+      an answer is required of the user).
+
+  The "answer" return value is True for "yes" or False for "no".
+  """
+  valid = {"yes": True, "y": True, "ye": True,
+           "no": False, "n": False}
+  if default is None:
+    prompt = " [y/n] "
+  elif default == "yes":
+    prompt = " [Y/n] "
+  elif default == "no":
+    prompt = " [y/N] "
+  else:
+    raise ValueError("invalid default answer: '%s'" % default)
+
+  while True:
+    sys.stdout.write(question + prompt)
+    if sys.version_info[0] == 3:
+      choice = input().lower() # if version 3 of Python
+    else:
+      choice = raw_input().lower()
+    if default is not None and choice == '':
+      return valid[default]
+    elif choice in valid:
+      return valid[choice]
+    else:
+      sys.stdout.write("Please respond with 'yes' or 'no' "
+                         "(or 'y' or 'n').\n")
+
+
+def rename_class(current_class_name, new_class_name):
+  # get list of txt files
+  file_list = glob.glob('*.txt')
+  file_list.sort()
+  # iterate through the txt files
+  for txt_file in file_list:
+    class_found = False
+    # open txt file lines to a list
+    with open(txt_file) as f:
+      content = f.readlines()
+    # remove whitespace characters like `\n` at the end of each line
+    content = [x.strip() for x in content]
+    new_content = []
+    # go through each line of eache file
+    for line in content:
+      #class_name = line.split()[0]
+      if current_class_name in line:
+        class_found = True
+        line = line.replace(current_class_name, new_class_name)
+      new_content.append(line)
+    if class_found:
+      # rewrite file
+      with open(txt_file, 'w') as new_f:
+        for line in new_content:
+          new_f.write("%s\n" % line)
+
+with open('class_list.txt') as f:
+    for line in f:
+        current_class_name = line
+        new_class_name = line.replace(' ', args.delimiter)
+        if line == new_class_name:
+            continue
+        y_n_message = ("Are you sure you want "
+                       "to rename the class "
+                       "\"" + current_class_name + "\" "
+                       "into \"" + new_class_name + "\"?"
+                      )
+
+                  
+        if query_yes_no(y_n_message, bypass=args.yes):
+          os.chdir("../ground-truth")
+          rename_class(current_class_name, new_class_name)
+          os.chdir("../predicted")
+          rename_class(current_class_name, new_class_name)
+
+print('Done!')


### PR DESCRIPTION
This script is designed to be used instead of `rename_class.py` when there are a lot of classes with spaces.
Because running `rename_class.py` with lots of classes would be tedious.
E.g. if we have classes like this:
```
license plate
0 zero
1 one
2 two
```
We would only need to run `remove_space.py` once to replace spaces with delimiter like so:
```
license-plate
0-zero
1-one
2-two
```
And of course, the delimiter is adjustable.