### PR TITLE
Update remove_space.py so documented example works

### DIFF
--- a/extra/remove_space.py
+++ b/extra/remove_space.py
@@ -35,7 +35,7 @@ def query_yes_no(question, default="yes", bypass=False):
   while True:
     sys.stdout.write(question + prompt)
     if bypass:
-        break
+        return True
     if sys.version_info[0] == 3:
       choice = input().lower() # if version 3 of Python
     else:


### PR DESCRIPTION
The example in the readme indicates that 

`python remove_space.py --delimiter "-" --yes`

should bypass the interactive query

it doesn't work, because the query function returns none instead of true when bypass=True