### PR TITLE
extra script to create union between ground truth and prediction

### DIFF
--- a/extra/union-gt-and-pred.py
+++ b/extra/union-gt-and-pred.py
@@ -1,0 +1,58 @@
+import sys
+import os
+import glob
+
+## This script ensures same number of files in ground-truth and predicted folder.
+## When you encounter file not found error, it's usually because you have
+## mismatched numbers of ground-truth and predicted files.
+## You can use this script to move ground-truth and predicted files that are
+## not in the intersection into a backup folder (backup_no_matches_found).
+## This will retain only files that have the same name in both folders.
+
+# change directory to the one with the files to be changed
+path_to_gt = '../ground-truth'
+path_to_pred = '../predicted'
+
+os.chdir(path_to_gt)
+gt_files = glob.glob('*.txt')
+if len(gt_files) == 0:
+    print("Error: no .txt files found in", path_to_gt)
+    sys.exit()
+os.chdir(path_to_pred)
+pred_files = glob.glob('*.txt')
+if len(pred_files) == 0:
+    print("Error: no .txt files found in", path_to_pred)
+    sys.exit()
+
+gt_files = set(gt_files)
+pred_files = set(pred_files)
+print('total ground-truth files:', len(gt_files))
+print('total predicted files:', len(pred_files))
+print()
+
+gt_backup = gt_files - pred_files
+pred_backup = pred_files - gt_files
+
+print("gt_backup:", gt_backup)
+print("pre_backup:", pred_backup)
+
+def backup(src_folder, backup_files, dst_folder):
+    # non-intersection files (txt format) will be moved to a backup folder
+    if not backup_files:
+        print('No backup required for', src_folder)
+        return
+    os.chdir(src_folder)
+    ## create the backup dir if it doesn't exist already
+    for file in backup_files:
+        open(dst_folder + '/' + file, 'w').close()
+    
+backup(path_to_gt, gt_backup, path_to_pred)
+backup(path_to_pred, pred_backup, path_to_gt)
+if gt_backup:
+    print('total ground-truth backup files:', len(gt_backup))
+if pred_backup:
+    print('total predicted backup files:', len(pred_backup))
+
+intersection = gt_files | pred_files
+print('total union files:', len(intersection))
+print("Union completed!")

--- a/extra/union-gt-and-pred.py
+++ b/extra/union-gt-and-pred.py
@@ -5,9 +5,12 @@ import glob
 ## This script ensures same number of files in ground-truth and predicted folder.
 ## When you encounter file not found error, it's usually because you have
 ## mismatched numbers of ground-truth and predicted files.
-## You can use this script to move ground-truth and predicted files that are
-## not in the intersection into a backup folder (backup_no_matches_found).
-## This will retain only files that have the same name in both folders.
+## You can use this script to create missing files as empty file. The rationale 
+## behind is the following:
+##  - if a file is missing from the ground truth but is present among the 
+##    predictions it means that we have false positives
+##  - if a file is missing from the predictions but is present in the ground
+##    truth it means that we have a false negative
 
 # change directory to the one with the files to be changed
 path_to_gt = '../ground-truth'
@@ -28,18 +31,14 @@ gt_files = set(gt_files)
 pred_files = set(pred_files)
 print('total ground-truth files:', len(gt_files))
 print('total predicted files:', len(pred_files))
-print()
 
 gt_backup = gt_files - pred_files
 pred_backup = pred_files - gt_files
 
-print("gt_backup:", gt_backup)
-print("pre_backup:", pred_backup)
-
 def backup(src_folder, backup_files, dst_folder):
     # non-intersection files (txt format) will be moved to a backup folder
     if not backup_files:
-        print('No backup required for', src_folder)
+        print('No missing file in', dst_folder)
         return
     os.chdir(src_folder)
     ## create the backup dir if it doesn't exist already
@@ -49,10 +48,10 @@ def backup(src_folder, backup_files, dst_folder):
 backup(path_to_gt, gt_backup, path_to_pred)
 backup(path_to_pred, pred_backup, path_to_gt)
 if gt_backup:
-    print('total ground-truth backup files:', len(gt_backup))
+    print('total predicted added files:', len(gt_backup))
 if pred_backup:
-    print('total predicted backup files:', len(pred_backup))
+    print('total ground-truth added files:', len(pred_backup))
 
-intersection = gt_files | pred_files
-print('total union files:', len(intersection))
+union = gt_files | pred_files
+print('total union files:', len(union))
 print("Union completed!")


### PR DESCRIPTION
When you encounter file not found error, it's usually because you have
mismatched numbers of ground-truth and predicted files.
You can use this script to create missing files as empty file. The rationale 
behind is the following:
  - if a file is missing from the ground truth but is present among the predictions it means that we have false positives
 - if a file is missing from the predictions but is present in the ground truth it means that we have a false negative
