### PR TITLE
bugfix: image read error while drawing FN

### DIFF
--- a/main.py
+++ b/main.py
@@ -741,6 +741,9 @@ for tmp_file in gt_files:
     img_id = tmp_file[tmp_file.find(start)+len(start):tmp_file.rfind('_ground_truth.json')]
     img_cumulative_path = output_files_path + "/images/" + img_id + ".jpg"
     img = cv2.imread(img_cumulative_path)
+    if img is None:
+        img_path = IMG_PATH + '/' + img_id + ".jpg"
+        img = cv2.imread(img_path)
     # draw false negatives
     for obj in ground_truth_data:
         if not obj['used']:


### PR DESCRIPTION
When there is no detection on an image, detection_results/image_id.txt is empty. Hence, no image will be written to the output_files_path/images directory. So following error will be thrown,

```
File "../mAP/main.py", line 760, in <module>
    cv2.imwrite(img_cumulative_path, img)
cv2.error: OpenCV(4.2.0) /io/opencv/modules/imgcodecs/src/loadsave.cpp:715: error: (-215:Assertion failed) !_img.empty() in function 'imwrite'
```
