### PR TITLE
canvas manager set title to avoid deprecation warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -701,7 +701,7 @@ with open(output_files_path + "/output.txt", 'w') as output_file:
             plt.fill_between(area_under_curve_x, 0, area_under_curve_y, alpha=0.2, edgecolor='r')
             # set window title
             fig = plt.gcf() # gcf - get current figure
-            fig.canvas.set_window_title('AP ' + class_name)
+            fig.canvas.manager.set_window_title('AP ' + class_name)
             # set plot title
             plt.title('class: ' + text)
             #plt.suptitle('This is a somewhat long figure title', fontsize=16)


### PR DESCRIPTION
Helps remove the matplotlib deprecation warning